### PR TITLE
validator.validateContext parameters are wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ At the beginning of your Lambda handler function, add the context validation. Fo
 ```javascript
 exports.handler = function(request, context) {
 	try {
-		validator.validateContext(request, response);
+		validator.validateContext(context);
 	} catch (error) {
 	    log('FATAL', error);
 	    throw(error);


### PR DESCRIPTION
validateContext has the context as parameter, not the request and response